### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -4,15 +4,23 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import java.util.ArrayList;
-import java.util.List;
-import java.io.IOException;
-import java.net.*;
 
+import java.util.List;
+import java.util.ArrayList;
+import java.net.*;
+import java.io.IOException;
+import java.util.logging.Logger;
 
 public class LinkLister {
+
+  private static final Logger logger = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // private constructor to hide the implicit public one
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -23,15 +31,15 @@ public class LinkLister {
 
   public static List<String> getLinksV2(String url) throws BadRequest {
     try {
-      URL aUrl= new URL(url);
+      URL aUrl = new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
-      if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
+      logger.info(host);
+      if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")) {
         throw new BadRequest("Use of Private IP");
       } else {
         return getLinks(url);
       }
-    } catch(Exception e) {
+    } catch (Exception e) {
       throw new BadRequest(e.getMessage());
     }
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 842386d5a8d8abc941ec1b2558b19eae1fb4bee1

**Descrição:** Este pull request traz várias mudanças no arquivo 'LinkLister.java'. As alterações incluem a reorganização de importações, a adição de um logger, a criação de um construtor privado para a classe e várias melhorias na formatação e no estilo do código.

**Sumario:**
- Arquivo src/main/java/com/scalesec/vulnado/LinkLister.java (modificado)
- Importações foram reorganizadas.
- Adicionado um logger para substituir a saída padrão do sistema.
- Criado um construtor privado para esconder o construtor público implícito.
- Melhorias na formatação e no estilo do código, como adicionar espaços para melhor legibilidade e substituir 'ArrayList<String>' por 'ArrayList<>'.
- Não foi adicionada uma nova linha ao final do arquivo, o que é uma prática recomendada.

**Recomendações:** Recomendo que o revisor preste atenção à ausência de uma nova linha ao final do arquivo, que é uma convenção comum para arquivos de texto e pode evitar problemas com algumas ferramentas que esperam essa nova linha. Além disso, é importante verificar se o logger foi corretamente implementado e se está funcionando como esperado.