### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -22,7 +22,7 @@ public class LinkLister {
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
-    Elements links = doc.select("a");
+    Elements links = doc.select("a[href]");
     for (Element link : links) {
       result.add(link.absUrl("href"));
     }
@@ -43,7 +43,7 @@ public class LinkLister {
       throw new BadRequest(e.getMessage());
     }
   }
-  
+
   public static class BadRequest extends Exception {
     public BadRequest(String message) {
       super(message);


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o f31a5d475384e505921ca7d79973ec5eae1bc93a
                                            
**Descrição:** O Pull Request 26 com o título '[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java', traz alterações no arquivo LinkLister.java localizado no caminho src/main/java/com/scalesec/vulnado/. As modificações tratam de uma mudança na seleção de elementos do tipo link em uma página HTML.

**Sumário:**

- src/main/java/com/scalesec/vulnado/LinkLister.java (modificado)

As alterações foram:
  - Na linha 22, o método `getLinks` que faz a seleção de elementos do tipo link (tag "a") em um documento HTML, foi alterado para selecionar apenas os links que possuem atributo href (links válidos).
  - Na linha 43, foi removido um espaço em branco, o que não altera a funcionalidade do código.

**Recomendações:** Recomendo que o revisor confirme se a seleção de apenas links com atributo href é realmente o comportamento desejado para o método `getLinks`. Além disso, é importante verificar se a remoção do espaço em branco na linha 43 não foi feita acidentalmente. 

No caso de testes, sugiro que sejam feitos em diferentes tipos de páginas HTML para confirmar se o método `getLinks` está funcionando corretamente após a alteração.